### PR TITLE
Do not throw when file is not found on gitlab

### DIFF
--- a/deploy-summary/lib/providers/gitlab.js
+++ b/deploy-summary/lib/providers/gitlab.js
@@ -135,7 +135,7 @@ module.exports = {
       return content
     } catch (error) {
       // no file found
-      if (error.status === 404) {
+      if (error.response && error.response.status === 404) {
         return undefined
       }
 


### PR DESCRIPTION
https://app.clubhouse.io/vercel/story/5260

The error object thrown from the `ky` module via the `gitlab` module does not have the `status` property but does `response` which is an instance of `fetch` response as far as I read the code.
See https://github.com/sindresorhus/ky/blob/07838c79e66b74f4d365b4c5ac82c5c9c18039b8/index.js#L107