### PR TITLE
[deploy-summary] Fix `mongo.closeStore()`

### DIFF
--- a/deploy-summary/lib/mongo.js
+++ b/deploy-summary/lib/mongo.js
@@ -15,9 +15,9 @@ module.exports = {
       .collection('build-summary-store')
   },
   closeStore: async () => {
-    client = null
     if (client) {
       await client.close()
     }
+    client = null
   }
 }


### PR DESCRIPTION
The `client` variable was set to `null` before we close it, so the function was not behaving as expected. The function is not used anywhere, but we should still fix it for correctness.

Thanks @chibicode for reporting this.