### PR TITLE
[gcloud] remove unused listProjects method

### DIFF
--- a/gcloud/.gitignore
+++ b/gcloud/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env.*
 .log
 .DS_Store
+.vercel

--- a/gcloud/now.json
+++ b/gcloud/now.json
@@ -4,7 +4,7 @@
   "version": 2,
   "builds": [
     { "src": "src/index.ts", "use": "@now/node@canary" },
-    { "src": "static/*.png", "use": "@now/optipng" },
+    { "src": "static/*.png", "use": "@now/static" },
     { "src": "static/*.svg", "use": "@now/static" }
   ],
   "routes": [

--- a/gcloud/src/utils/ui-hook/fieldsets/scheduler.ts
+++ b/gcloud/src/utils/ui-hook/fieldsets/scheduler.ts
@@ -61,7 +61,7 @@ const Job = ({ job }: { job: cloudscheduler_v1beta1.Schema$Job }) => {
 const methods = ['GET', 'POST', 'DELETE', 'PUT', 'PATCH', 'HEAD', 'OPTIONS']
 
 const SchedulerFieldset = ({ jobs, error, deployments, productionAliases, disabled, apiDisabled }: SchedulerFieldsetProps) => {
-  const targetUrls = [...productionAliases, ...(deployments || []).map(deployment => deployment.url)]
+  const targetUrls = [...(productionAliases || []), ...(deployments || []).map(deployment => deployment.url)]
 
   return html`
     <Fieldset>

--- a/gcloud/src/utils/zeit-api.ts
+++ b/gcloud/src/utils/zeit-api.ts
@@ -128,22 +128,6 @@ export default class ZEIT {
     return 'production' in project.targets ? project.targets.production.alias : []
   }
 
-  listProjects = async () => {
-    console.log('Fetching user projects')
-
-    const res = await this.client.fetch(`/projects/list?limit=500`, {
-      teamId: this.teamId
-    } as any)
-
-    const projects = await res.json()
-
-    if (projects.error) {
-      throw new ZEITError(JSON.stringify(projects.error))
-    }
-
-    return projects
-  }
-
   // Extract fields from the `clientState`
   get = (field: string) => this.payload.clientState[field]
 


### PR DESCRIPTION
We want to ensure to not use the old projects API. It seems this method is not used at all so just remove it.

https://app.clubhouse.io/vercel/story/16899