### PR TITLE
[datadog-logs] fix body used already error

### DIFF
--- a/datadog-logs/lib/set-metadata.js
+++ b/datadog-logs/lib/set-metadata.js
@@ -17,10 +17,9 @@ module.exports = async ({ configurationId, teamId, token }, data) => {
     }
   );
 
-  const body = await res.json();
   if (!res.ok) {
     throw await responseError(res);
   }
 
-  return body;
+  return await res.json();
 };


### PR DESCRIPTION
When API call failed, it used to consume body twice.