### PR TITLE
[deploy-summary] Do not screenshot dynamic routes

### DIFF
--- a/deploy-summary/lib/frameworks.js
+++ b/deploy-summary/lib/frameworks.js
@@ -40,7 +40,15 @@ module.exports = [
       baseDirs: ['pages/', 'src/pages/'],
       filter: ['/_app', '/_document']
     }),
-    shouldScreenshot: route => !route.startsWith('/api/')
+    shouldScreenshot: route => {
+      // do not screenshot api routes
+      if (route.startsWith('/api/')) return false
+
+      // do not screenshot dynamic routes
+      if (/\[/.test(route) && /\]/.test(route)) return false
+
+      return true
+    }
   },
   {
     dependency: 'gatsby',


### PR DESCRIPTION
Skip adding screenshots for dynamic routes, and instead put them in the "other routes" list.